### PR TITLE
feat: convert new issue dialog to prompt-based workflow with AI elaboration

### DIFF
--- a/src/app/api/projects/[id]/issues/route.ts
+++ b/src/app/api/projects/[id]/issues/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { exec } from "child_process";
 import { promisify } from "util";
 import { configService } from "@/lib/services/config";
+import { openCodeService } from "@/lib/services/opencode";
+import { sessionStorage } from "@/lib/services/sessions";
 
 const execAsync = promisify(exec);
 
@@ -77,6 +79,34 @@ export async function GET(
   }
 }
 
+/**
+ * Generate a clean title from the user's prompt.
+ * - Replaces newlines with spaces (prompts can be multi-line)
+ * - Truncates to ~80 chars, breaking at word boundary
+ * - Adds ellipsis if truncated
+ */
+const generateInitialTitle = (text: string): string => {
+  // Clean up: replace newlines and collapse whitespace
+  const cleaned = text.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+  
+  const maxLength = 80;
+  if (cleaned.length <= maxLength) {
+    return cleaned;
+  }
+  
+  // Try to break at a word boundary
+  const truncated = cleaned.substring(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(' ');
+  
+  if (lastSpace > maxLength * 0.5) {
+    // Break at word boundary if we're not losing too much
+    return truncated.substring(0, lastSpace) + '...';
+  }
+  
+  // Otherwise just truncate
+  return truncated.substring(0, maxLength - 3) + '...';
+};
+
 // POST /api/projects/[id]/issues - Create a new GitHub issue
 export async function POST(
   request: Request,
@@ -85,11 +115,13 @@ export async function POST(
   try {
     const { id } = await params;
     const body = await request.json();
-    const { title } = body;
+    const { prompt } = body;
 
-    if (!title || typeof title !== "string") {
-      return NextResponse.json({ error: "Title is required" }, { status: 400 });
+    if (!prompt || typeof prompt !== "string") {
+      return NextResponse.json({ error: "Prompt is required" }, { status: 400 });
     }
+
+    const initialTitle = generateInitialTitle(prompt);
 
     // Get project to find path
     const project = await configService.getProject(id);
@@ -102,9 +134,17 @@ export async function POST(
 
     // Create issue using gh CLI
     // gh issue create doesn't support --json, so we create first then fetch
-    const escapedTitle = title.replace(/"/g, '\\"');
+    // Escape shell special characters in the title
+    const escapedTitle = initialTitle
+      .replace(/\\/g, '\\\\')   // Escape backslashes first
+      .replace(/"/g, '\\"')     // Escape double quotes
+      .replace(/\$/g, '\\$')    // Escape dollar signs (prevent shell expansion)
+      .replace(/`/g, '\\`');    // Escape backticks
+
+    const placeholderBody = 'Generating description...';
+
     const { stdout: createStdout, stderr: createStderr } = await execAsync(
-      `gh issue create --title "${escapedTitle}" --body ""`,
+      `gh issue create --title "${escapedTitle}" --body "${placeholderBody}"`,
       { cwd }
     );
 
@@ -127,6 +167,72 @@ export async function POST(
     );
     
     const issue: GitHubIssue = JSON.parse(issueStdout);
+
+    // Create OpenCode session for this issue
+    let sessionId: string | undefined;
+    try {
+      // Note: issueNumber is available from line 159 (from URL regex match)
+      // initialTitle is the truncated prompt from generateInitialTitle()
+      const session = await openCodeService.createSession(
+        cwd,
+        `Issue #${issueNumber}: ${initialTitle}`
+      );
+      sessionId = session.id;
+      
+      // Save session mapping for later retrieval
+      // Note: issueNumber is a string, but saveSession expects number
+      await sessionStorage.saveSession(id, cwd, parseInt(issueNumber), sessionId);
+
+      // Inject context instructing agent to update the issue
+      const contextText = `
+You are helping with GitHub issue #${issueNumber} in this repository.
+
+The user has provided a prompt describing what they want to build or explore. Your job is to:
+
+1. **Explore the codebase** to understand the relevant context, existing patterns, and potential impact areas.
+
+2. **Update the GitHub issue** with a clear title and comprehensive description. 
+   
+   IMPORTANT: Use a heredoc or --body-file for the body to handle special characters safely:
+   
+   \`\`\`bash
+   gh issue edit ${issueNumber} --title "<improved title>" --body-file /dev/stdin << 'ISSUEBODY'
+   ## Summary
+   ...your markdown content...
+   ISSUEBODY
+   \`\`\`
+   
+   Alternatively, for simpler content:
+   gh issue edit ${issueNumber} --title "<improved title>" --body "<markdown description>"
+
+3. **Format the description** with these sections as appropriate:
+   - **Summary**: 1-2 sentences explaining the goal
+   - **Background**: Why this is needed, what problem it solves
+   - **Requirements**: Specific things that need to be implemented
+   - **Technical Approach**: How to implement it, what files/components are involved
+   - **Acceptance Criteria**: How to verify the work is complete
+   - **Open Questions**: Any decisions that need to be made
+
+**Important:**
+- The title should be clear, concise, and in imperative mood (e.g., "Add dark mode toggle to settings")
+- The description should be comprehensive enough that another developer could implement it
+- Include file paths, function names, and other specific references discovered during exploration
+- If the prompt is vague, make reasonable assumptions and note them as open questions
+- Escape any special shell characters in your commands, or use heredocs for safety
+
+After you update the issue, briefly confirm what you did and ask if the user wants to refine anything.
+`;
+
+      await openCodeService.injectContext(cwd, sessionId, contextText);
+
+      // Send the user's prompt to the agent
+      // This is fire-and-forget - agent will work asynchronously
+      await openCodeService.sendMessageWithBashAsync(cwd, sessionId, prompt.trim());
+    } catch (sessionError) {
+      // Log but don't fail - issue was created successfully
+      // User can still interact with the issue, just won't have the AI session
+      console.error("Failed to create OpenCode session:", sessionError);
+    }
 
     return NextResponse.json(issue, { status: 201 });
   } catch (error) {

--- a/src/components/new-issue-dialog/NewIssueDialog.tsx
+++ b/src/components/new-issue-dialog/NewIssueDialog.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Loader2 } from "lucide-react";
 
@@ -29,14 +29,14 @@ export function NewIssueDialog({
   onOpenChange,
 }: NewIssueDialogProps) {
   const router = useRouter();
-  const [title, setTitle] = useState("");
+  const [prompt, setPrompt] = useState("");
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    if (!title.trim()) return;
+    if (!prompt.trim()) return;
 
     setIsCreating(true);
     setError(null);
@@ -46,7 +46,7 @@ export function NewIssueDialog({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ 
-          title: title.trim(),
+          prompt: prompt.trim(),
           projectPath,
         }),
       });
@@ -60,7 +60,7 @@ export function NewIssueDialog({
       
       // Close dialog and navigate to the issue view
       onOpenChange(false);
-      setTitle("");
+      setPrompt("");
       router.push(`/project/${projectId}/issue/${data.number}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create issue");
@@ -73,7 +73,7 @@ export function NewIssueDialog({
     if (!isCreating) {
       onOpenChange(newOpen);
       if (!newOpen) {
-        setTitle("");
+        setPrompt("");
         setError(null);
       }
     }
@@ -86,20 +86,21 @@ export function NewIssueDialog({
           <DialogHeader>
             <DialogTitle>New Issue</DialogTitle>
             <DialogDescription>
-              Create a new GitHub issue to start exploring an idea with the agent.
+              Describe what you want to build or explore. The agent will create a GitHub
+              issue and elaborate your request with relevant technical context.
             </DialogDescription>
           </DialogHeader>
           
           <div className="py-4">
-            <Label htmlFor="issue-title" className="text-sm font-medium">
-              Title
+            <Label htmlFor="issue-prompt" className="text-sm font-medium">
+              Prompt
             </Label>
-            <Input
-              id="issue-title"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="What would you like to explore?"
-              className="mt-2"
+            <Textarea
+              id="issue-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Describe what you want to build or explore..."
+              className="mt-2 min-h-[100px] resize-none"
               autoFocus
               disabled={isCreating}
             />
@@ -117,7 +118,7 @@ export function NewIssueDialog({
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={!title.trim() || isCreating}>
+            <Button type="submit" disabled={!prompt.trim() || isCreating}>
               {isCreating ? (
                 <>
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />


### PR DESCRIPTION
## Summary

- Replaces the simple title input with a multi-line prompt textarea for describing what you want to build
- Creates an OpenCode session when the issue is created
- Agent automatically explores the codebase and elaborates the prompt into a comprehensive issue description

## Changes

**Frontend (NewIssueDialog.tsx):**
- Replaced `Input` with `Textarea` for multi-line prompts
- Updated copy to explain the new workflow
- Changed field from `title` to `prompt`

**Backend (route.ts):**
- Added `generateInitialTitle()` function to create a clean title from the prompt (truncated to ~80 chars at word boundary)
- Creates OpenCode session for the new issue
- Injects context instructing the agent to:
  - Explore the codebase for relevant context
  - Update the GitHub issue with improved title and comprehensive description
  - Structure description with: Summary, Background, Requirements, Technical Approach, Acceptance Criteria, Open Questions
- Sends the user's prompt to the agent asynchronously

## How it works

1. User enters a prompt describing what they want to build
2. Issue is created with a truncated title and placeholder body
3. OpenCode session is created and given instructions to elaborate
4. Agent explores codebase and updates the issue with a detailed description
5. User is navigated to the issue view where they can see the agent working