### PR TITLE
fix: replace fs.watch with bd activity subprocess for real-time bead updates

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/api/projects/[id]/planning/[issueNumber]/beads/watch/route.ts
+++ b/src/app/api/projects/[id]/planning/[issueNumber]/beads/watch/route.ts
@@ -1,12 +1,24 @@
 // Beads Watch API - Server-Sent Events for real-time bead updates
 // GET /api/projects/{id}/planning/{issueNumber}/beads/watch
 //
-// This endpoint uses file system watching on the `.beads/` directory to detect
-// when the AI agent creates or modifies beads, enabling real-time UI updates.
+// This endpoint uses the `bd activity --follow` subprocess to receive real-time
+// bead mutation events. When the AI agent creates or modifies beads, events are
+// streamed via NDJSON and trigger UI updates.
+//
+// Architecture:
+// - Spawns `bd activity --follow --json --since 0s` subprocess
+// - Parses NDJSON events (one JSON object per line)
+// - Triggers debounced bead list refresh on any mutation event
+// - Automatic restart with backoff on subprocess failure
+// - Falls back to 5-second polling if subprocess repeatedly fails
+//
+// Why subprocess instead of fs.watch:
+// - Worktrees share the main repo's .beads/ directory (no local .beads/)
+// - bd activity watches SQLite mutations directly, not file exports
+// - No platform-specific inotify/FSEvents issues
+// - Semantic events (create/update/delete) instead of raw file changes
 
-import { watch, FSWatcher } from "fs";
-import { access, constants } from "fs/promises";
-import path from "path";
+import { spawn, ChildProcess } from "child_process";
 import { configService } from "@/lib/services/config";
 import { worktreeService } from "@/lib/services/worktree";
 import { beadsService, Bead, BeadsError } from "@/lib/services/beads";
@@ -14,6 +26,8 @@ import { beadsService, Bead, BeadsError } from "@/lib/services/beads";
 // Constants
 const DEBOUNCE_MS = 100;
 const POLL_INTERVAL_MS = 5000;
+const RESTART_DELAY_MS = 1000;      // Base delay before restart
+const MAX_RESTART_ATTEMPTS = 5;      // Max restarts before polling fallback
 
 interface BeadsUpdateEvent {
   type: "update";
@@ -33,18 +47,6 @@ interface BeadsConnectedEvent {
 }
 
 type BeadsEvent = BeadsUpdateEvent | BeadsErrorEvent | BeadsConnectedEvent;
-
-/**
- * Check if a directory exists and is accessible
- */
-async function directoryExists(dirPath: string): Promise<boolean> {
-  try {
-    await access(dirPath, constants.R_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * GET /api/projects/{id}/planning/{issueNumber}/beads/watch
@@ -90,7 +92,6 @@ export async function GET(
   }
 
   const worktreePath = worktree.path;
-  const beadsDir = path.join(worktreePath, ".beads");
 
   // Create SSE stream
   const stream = new ReadableStream({
@@ -101,7 +102,10 @@ export async function GET(
       let isCleanedUp = false;
       let debounceTimer: NodeJS.Timeout | null = null;
       let pollInterval: NodeJS.Timeout | null = null;
-      let watcher: FSWatcher | null = null;
+      // Subprocess tracking
+      let activityProc: ChildProcess | null = null;  // Subprocess handle
+      let lineBuffer = "";                           // Buffer for incomplete NDJSON lines
+      let restartAttempts = 0;                       // Track restart attempts for backoff
 
       /**
        * Send an SSE event to the client
@@ -182,13 +186,10 @@ export async function GET(
           pollInterval = null;
         }
 
-        if (watcher) {
-          try {
-            watcher.close();
-          } catch {
-            // Ignore close errors
-          }
-          watcher = null;
+        // Kill the activity subprocess
+        if (activityProc) {
+          activityProc.kill("SIGTERM");
+          activityProc = null;
         }
 
         try {
@@ -204,7 +205,7 @@ export async function GET(
       function startPolling(): void {
         if (isCleanedUp || pollInterval) return;
 
-        console.log(`[beads-watch] File watching unavailable, falling back to polling (${POLL_INTERVAL_MS}ms)`);
+        console.log(`[beads-watch] Falling back to polling (${POLL_INTERVAL_MS}ms)`);
 
         pollInterval = setInterval(() => {
           if (!isCleanedUp) {
@@ -214,65 +215,93 @@ export async function GET(
       }
 
       /**
-       * Set up file watcher for the .beads directory
+       * Start bd activity subprocess for real-time bead updates
        */
-      async function setupWatcher(): Promise<void> {
-        // Check if .beads directory exists
-        const beadsDirExists = await directoryExists(beadsDir);
+      function startActivityStream(): void {
+        if (isCleanedUp) return;
 
-        if (!beadsDirExists) {
-          // Directory doesn't exist yet - start polling until it's created
-          // This handles the case where planning hasn't started yet
-          console.log(`[beads-watch] .beads directory doesn't exist yet, waiting...`);
-          startPolling();
-          return;
-        }
+        // Use --since 0s to skip historical events, only receive new ones
+        activityProc = spawn("bd", ["activity", "--follow", "--json", "--since", "0s"], {
+          cwd: worktreePath,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
 
-        try {
-          // Watch for changes in the .beads directory
-          watcher = watch(beadsDir, { recursive: true }, (eventType, filename) => {
-            // Ignore non-relevant events
-            if (!filename) return;
+        // Track successful operation to reset restart counter
+        let hasReceivedData = false;
 
-            // Only react to .json file changes (beads data files)
-            if (filename.endsWith(".json") || filename.endsWith(".jsonl")) {
+        // Handle stdout (NDJSON event stream)
+        activityProc.stdout?.on("data", (data: Buffer) => {
+          if (isCleanedUp) return;
+
+          // First data received = process is working, reset restart counter
+          if (!hasReceivedData) {
+            hasReceivedData = true;
+            restartAttempts = 0;  // Reset on successful operation
+          }
+
+          // Append to line buffer and parse complete lines
+          lineBuffer += data.toString();
+          const lines = lineBuffer.split("\n");
+          
+          // Keep incomplete last line in buffer
+          lineBuffer = lines.pop() || "";
+
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+
+            try {
+              // Parse to validate JSON
+              // Any valid event means something changed - trigger refresh
+              JSON.parse(trimmed);
               debouncedSendBeads();
+            } catch {
+              // Not valid JSON - might be a partial line or log message
+              // Ignore silently
             }
-          });
+          }
+        });
 
-          // Handle watcher errors
-          watcher.on("error", (error) => {
-            console.error("[beads-watch] Watcher error:", error);
+        // Handle stderr (warnings/errors from bd)
+        activityProc.stderr?.on("data", (data: Buffer) => {
+          // Log but don't treat as fatal - bd may output warnings
+          console.warn("[beads-watch] bd stderr:", data.toString().trim());
+        });
 
-            // Close the broken watcher
-            if (watcher) {
-              try {
-                watcher.close();
-              } catch {
-                // Ignore
-              }
-              watcher = null;
-            }
+        // Handle spawn error (e.g., bd not found)
+        activityProc.on("error", (err) => {
+          console.error("[beads-watch] Activity process spawn error:", err);
+          activityProc = null;
 
-            // Fall back to polling
+          if (!isCleanedUp) {
+            sendEvent({ type: "error", error: "Activity stream failed to start" });
             startPolling();
-          });
+          }
+        });
 
-          // Handle watcher close
-          watcher.on("close", () => {
-            watcher = null;
-            // If not cleaned up, this was unexpected - start polling
-            if (!isCleanedUp) {
-              startPolling();
-            }
-          });
+        // Handle process exit
+        activityProc.on("close", (code) => {
+          activityProc = null;
+          if (isCleanedUp) return;
 
-          console.log(`[beads-watch] Watching ${beadsDir}`);
-        } catch (error) {
-          console.error("[beads-watch] Failed to set up watcher:", error);
-          // Fall back to polling
-          startPolling();
-        }
+          console.log(`[beads-watch] Activity process exited with code ${code}`);
+
+          // Attempt restart with linear backoff
+          if (restartAttempts < MAX_RESTART_ATTEMPTS) {
+            restartAttempts++;
+            const delay = RESTART_DELAY_MS * restartAttempts;
+            console.log(`[beads-watch] Restarting in ${delay}ms (attempt ${restartAttempts}/${MAX_RESTART_ATTEMPTS})`);
+            
+            setTimeout(() => {
+              if (!isCleanedUp) startActivityStream();
+            }, delay);
+          } else {
+            console.error("[beads-watch] Max restart attempts reached, falling back to polling");
+            startPolling();
+          }
+        });
+
+        console.log(`[beads-watch] Started bd activity --follow for ${worktreePath}`);
       }
 
       // Handle request abort (client disconnect)
@@ -290,8 +319,8 @@ export async function GET(
       // Send initial beads state
       await sendBeadsUpdate();
 
-      // Set up file watching (or polling fallback)
-      await setupWatcher();
+      // Start the bd activity stream for real-time updates
+      startActivityStream();
     },
   });
 

--- a/src/lib/services/beads-utils.ts
+++ b/src/lib/services/beads-utils.ts
@@ -1,0 +1,64 @@
+// Shared utility functions for filtering beads by issue
+// Used by both the beads list and watch routes
+
+import { Bead } from "./beads";
+
+/**
+ * Find the epic bead for a specific issue.
+ * Only matches epics that explicitly mention the issue number.
+ * 
+ * IMPORTANT: We intentionally do NOT fall back to "any epic" because
+ * the beads database is shared across all worktrees/issues. Falling back
+ * would show beads from unrelated issues.
+ * 
+ * Patterns we look for:
+ * - "(GH #12)" - standard format from planning agent
+ * - "#12" - short format
+ * - "issue 12" or "issue-12" - natural language
+ */
+export function findEpicBead(beads: Bead[], issueNumber: number): Bead | null {
+  return beads.find(
+    (b) =>
+      b.type === "epic" &&
+      (b.title.includes(`#${issueNumber}`) ||
+        b.title.toLowerCase().includes(`issue ${issueNumber}`) ||
+        b.title.toLowerCase().includes(`issue-${issueNumber}`))
+  ) || null;
+}
+
+/**
+ * Filter beads to only include those that are part of the given epic's tree.
+ * Returns the epic and all its descendants (children, grandchildren, etc.)
+ */
+export function filterBeadsByEpic(allBeads: Bead[], epic: Bead): Bead[] {
+  const epicDescendantIds = new Set<string>();
+  epicDescendantIds.add(epic.id);
+  
+  // Iteratively collect all descendants
+  // We need multiple passes since children reference parents
+  let foundNew = true;
+  while (foundNew) {
+    foundNew = false;
+    for (const bead of allBeads) {
+      if (bead.parent && epicDescendantIds.has(bead.parent) && !epicDescendantIds.has(bead.id)) {
+        epicDescendantIds.add(bead.id);
+        foundNew = true;
+      }
+    }
+  }
+  
+  return allBeads.filter((b) => epicDescendantIds.has(b.id));
+}
+
+/**
+ * Get beads for a specific issue from the full beads list.
+ * Returns only beads that belong to the issue's epic tree.
+ * Returns empty array if no epic found for the issue.
+ */
+export function getBeadsForIssue(allBeads: Bead[], issueNumber: number): Bead[] {
+  const epic = findEpicBead(allBeads, issueNumber);
+  if (!epic) {
+    return [];
+  }
+  return filterBeadsByEpic(allBeads, epic);
+}


### PR DESCRIPTION
## Summary

Fixes #12 - beads view not updating live during planning phase.

- Replace broken `fs.watch()` with `bd activity --follow` subprocess for real-time bead updates
- Add NDJSON line buffering for proper event parsing
- Implement automatic restart with linear backoff (5 attempts)
- Add graceful fallback to 5-second polling when subprocess fails
- Properly terminate subprocess on client disconnect (SIGTERM)

## Root Cause

The previous implementation used `fs.watch()` on a `.beads/` directory within the worktree. This failed because:
1. Worktrees don't have their own `.beads/` directory - they share the main repo's database
2. Even if it existed, the code watched for JSONL file changes, but beads uses SQLite
3. `fs.watch()` has platform-specific quirks with inotify/FSEvents

## Solution

Use `bd activity --follow --json --since 0s` subprocess which:
- Watches SQLite mutations directly (not file exports)
- Works with shared beads database across worktrees
- Provides semantic events (create/update/delete)
- Has no platform-specific file watching issues

## Testing

- [x] TypeScript compilation passes
- [x] ESLint passes (no new errors)
- [x] All 48 existing tests pass
- [ ] Manual testing: bead CRUD appears in UI within ~1 second
- [ ] Manual testing: no zombie processes after disconnect