### PR TITLE
feat: Add planning state with GitHub label filtering (GH #15)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@opencode-ai/sdk": "^1.0.214",
         "@radix-ui/react-accordion": "^1.2.12",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -352,6 +353,8 @@
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
     "@radix-ui/react-accordion": ["@radix-ui/react-accordion@1.2.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA=="],
+
+    "@radix-ui/react-alert-dialog": ["@radix-ui/react-alert-dialog@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw=="],
 
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 
@@ -1876,6 +1879,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@radix-ui/react-alert-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@opencode-ai/sdk": "^1.0.214",
     "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/src/app/api/projects/[id]/planning/[issueNumber]/end/route.ts
+++ b/src/app/api/projects/[id]/planning/[issueNumber]/end/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+import { configService } from "@/lib/services/config";
+import { sessionStorage } from "@/lib/services/sessions";
+import { worktreeService } from "@/lib/services/worktree";
+import { removePlanningLabel } from "@/lib/services/github-labels";
+
+interface EndPlanningRequest {
+  cleanup?: boolean;
+}
+
+interface EndPlanningResponse {
+  success: boolean;
+  labelRemoved: boolean;
+  sessionRemoved: boolean;
+  worktreeRemoved: boolean;
+  errors: string[];
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; issueNumber: string }> }
+) {
+  const { id: projectId, issueNumber: issueNumStr } = await params;
+  const issueNumber = parseInt(issueNumStr, 10);
+
+  if (isNaN(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json(
+      { error: "Invalid issue number" },
+      { status: 400 }
+    );
+  }
+
+  const project = await configService.getProject(projectId);
+  if (!project) {
+    return NextResponse.json(
+      { error: "Project not found" },
+      { status: 404 }
+    );
+  }
+
+  let cleanup = false;
+  try {
+    const body: EndPlanningRequest = await request.json();
+    cleanup = body.cleanup === true;
+  } catch {
+    // No body or invalid JSON - use defaults
+  }
+
+  const results: EndPlanningResponse = {
+    success: false,
+    labelRemoved: false,
+    sessionRemoved: false,
+    worktreeRemoved: false,
+    errors: [],
+  };
+
+  // 1. Remove planning label from GitHub issue
+  try {
+    await removePlanningLabel(project.path, issueNumber);
+    results.labelRemoved = true;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    results.errors.push(`Failed to remove label: ${msg}`);
+  }
+
+  // 2. Optionally clean up session and worktree
+  if (cleanup) {
+    try {
+      const removed = await sessionStorage.removeSession(
+        projectId, 
+        issueNumber, 
+        "planning"
+      );
+      results.sessionRemoved = removed;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      results.errors.push(`Failed to remove session: ${msg}`);
+    }
+
+    try {
+      await worktreeService.deleteWorktree(project.path, issueNumber);
+      results.worktreeRemoved = true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!msg.includes("not found") && !msg.includes("does not exist")) {
+        results.errors.push(`Failed to remove worktree: ${msg}`);
+      } else {
+        results.worktreeRemoved = true;
+      }
+    }
+  }
+
+  // Success if label was removed
+  results.success = results.labelRemoved;
+
+  return NextResponse.json(results);
+}

--- a/src/app/api/projects/[id]/planning/[issueNumber]/start/route.ts
+++ b/src/app/api/projects/[id]/planning/[issueNumber]/start/route.ts
@@ -1,4 +1,5 @@
 import { configService } from "@/lib/services/config";
+import { addPlanningLabel } from "@/lib/services/github-labels";
 import { openCodeService } from "@/lib/services/opencode";
 import { sessionStorage } from "@/lib/services/sessions";
 import { worktreeService, WorktreeInfo } from "@/lib/services/worktree";
@@ -277,6 +278,19 @@ export async function POST(
               sessionId,
               worktreeInfo.path
             );
+
+            // Add planning label to GitHub issue
+            // This is non-fatal - planning works even if label fails
+            try {
+              await addPlanningLabel(project.path, issueNumber);
+            } catch (err) {
+              // Log warning but dont fail the pipeline
+              // Label is for filtering convenience, not core functionality
+              console.warn(
+                `[Planning Start] Failed to add planning label to issue #${issueNumber}:`,
+                err instanceof Error ? err.message : err
+              );
+            }
 
             // Inject worktree context into the session so the AI knows where to work
             const worktreeContext = `<system-reminder>

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useParams } from "next/navigation";
 import { mockEpics, mockSoloSessions } from "@/lib/data/mock";
 import { NewIssueDialog } from "@/components/new-issue-dialog";
 import { useProject, useProjectIssues, usePlanningSessions } from "@/lib/hooks/useProjects";
+import { PLANNING_LABEL } from "@/lib/constants";
 import { CompactSessionCard, CompactIssueCard, CompactEpicCard, CompactSwarmCard, CompactPlanningCard } from "@/components/compact-cards";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -31,6 +32,12 @@ export default function ProjectOverviewPage() {
   const { data: issues = [], isLoading: issuesLoading } = useProjectIssues(projectId);
   const { data: planningSessions = [], isLoading: planningLoading } = usePlanningSessions(projectId);
   const [isNewIssueDialogOpen, setIsNewIssueDialogOpen] = useState(false);
+
+  // Filter out issues that are in planning
+  // These appear in the Planning column/section instead
+  const openIssues = issues.filter(
+    (issue) => !issue.labels?.some(label => label.name === PLANNING_LABEL)
+  );
 
   // Loading state
   if (!project) {
@@ -88,7 +95,7 @@ export default function ProjectOverviewPage() {
                   <CircleDot className="h-4 w-4 text-[hsl(var(--orange))]" />
                   <span className="font-medium">Issues</span>
                   <span className="text-xs text-muted-foreground bg-secondary rounded-full px-2 py-0.5">
-                    {issues.length}
+                    {openIssues.length}
                   </span>
                 </div>
               </AccordionTrigger>
@@ -107,8 +114,8 @@ export default function ProjectOverviewPage() {
                       <Skeleton className="h-16 w-full" />
                       <Skeleton className="h-16 w-full" />
                     </div>
-                  ) : issues.length > 0 ? (
-                    issues.map((issue) => (
+                  ) : openIssues.length > 0 ? (
+                    openIssues.map((issue) => (
                       <CompactIssueCard key={issue.number} issue={issue} projectId={projectId} />
                     ))
                   ) : (
@@ -208,12 +215,12 @@ export default function ProjectOverviewPage() {
               title="Issues"
               icon={<CircleDot className="h-3.5 w-3.5" />}
               iconColor="text-[hsl(var(--orange))]"
-              count={issues.length}
+              count={openIssues.length}
               accentColor="bg-[hsl(var(--orange))]"
               onAddClick={() => setIsNewIssueDialogOpen(true)}
               isLoading={issuesLoading}
             >
-              {issues.map((issue) => (
+              {openIssues.map((issue) => (
                 <IssueCard key={issue.number} issue={issue} projectId={projectId} />
               ))}
             </KanbanColumn>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -44,6 +44,7 @@ import {
   ClipboardList,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { PLANNING_LABEL } from "@/lib/constants";
 
 // Component to fetch and display planning sessions for a project
 function PlanningSessionsSection({
@@ -134,8 +135,13 @@ function ProjectIssuesSection({
   const { data: issues = [], isLoading } = useProjectIssues(project.id);
   const [isOpen, setIsOpen] = useState(true);
   
-  // Filter to only open issues
-  const openIssues = issues.filter((issue) => issue.state === "OPEN" || issue.state === "open");
+  // Filter to only open issues that are NOT in planning
+  // Issues in planning should only appear in the "Active Planning" section
+  const openIssues = issues.filter(
+    (issue) => 
+      (issue.state === "OPEN" || issue.state === "open") &&
+      !issue.labels?.some(label => label.name === PLANNING_LABEL)
+  );
   
   if (isLoading) {
     return (

--- a/src/components/planning/PlanningHeader.tsx
+++ b/src/components/planning/PlanningHeader.tsx
@@ -1,9 +1,23 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { ChevronLeft, ChevronRight, Square, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface PlanningHeaderProps {
   projectId: string;
@@ -18,6 +32,43 @@ export function PlanningHeader({
   issueTitle,
   projectName,
 }: PlanningHeaderProps) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [isEnding, setIsEnding] = useState(false);
+  const [showDialog, setShowDialog] = useState(false);
+
+  const handleEndPlanning = async () => {
+    setIsEnding(true);
+    try {
+      const response = await fetch(
+        `/api/projects/${projectId}/planning/${issueNumber}/end`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cleanup: false }),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await response.json();
+        console.error("Failed to end planning:", error);
+        return;
+      }
+
+      // Invalidate caches so UI updates immediately
+      await queryClient.invalidateQueries({ queryKey: ["project-issues", projectId] });
+      await queryClient.invalidateQueries({ queryKey: ["planning-sessions", projectId] });
+
+      // Navigate back to project overview
+      router.push(`/project/${projectId}`);
+    } catch (err) {
+      console.error("Error ending planning:", err);
+    } finally {
+      setIsEnding(false);
+      setShowDialog(false);
+    }
+  };
+
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-card">
       <div className="flex h-12 items-center gap-2 px-4">
@@ -47,7 +98,57 @@ export function PlanningHeader({
         </nav>
 
         {/* Actions */}
-        <div className="flex items-center gap-1 flex-shrink-0">
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {/* End Planning Button with Confirmation */}
+          <AlertDialog open={showDialog} onOpenChange={setShowDialog}>
+            <AlertDialogTrigger asChild>
+              <Button 
+                variant="outline" 
+                size="sm" 
+                className="gap-1.5"
+                disabled={isEnding}
+              >
+                {isEnding ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Square className="h-4 w-4" />
+                )}
+                <span className="hidden sm:inline">End Planning</span>
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>End Planning Session</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will remove the planning label from issue #{issueNumber} 
+                  and move it back to the Issues column.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <div className="py-4">
+                <p className="text-sm text-muted-foreground">
+                  The worktree branch and any uncommitted changes will be preserved.
+                  You can clean these up manually or restart planning later.
+                </p>
+              </div>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={isEnding}>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={handleEndPlanning}
+                  disabled={isEnding}
+                >
+                  {isEnding ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                      Ending...
+                    </>
+                  ) : (
+                    "End Planning"
+                  )}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+
           <Link href={`/project/${projectId}/issue/${issueNumber}`}>
             <Button variant="outline" size="sm" className="gap-1.5">
               <ChevronLeft className="h-4 w-4" />

--- a/src/components/planning/SetupProgress.tsx
+++ b/src/components/planning/SetupProgress.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState, useCallback, useRef } from "react"
+import { useQueryClient } from "@tanstack/react-query"
 import { Circle, Loader2, CheckCircle2, XCircle, RefreshCw } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
@@ -60,6 +61,7 @@ export function SetupProgress({
   onError,
   onSessionCreated,
 }: SetupProgressProps) {
+  const queryClient = useQueryClient()
   const [steps, setSteps] = useState<StepState[]>(INITIAL_STEPS)
   const [pipelineError, setPipelineError] = useState<string | null>(null)
   const [isRetrying, setIsRetrying] = useState(false)
@@ -174,6 +176,9 @@ export function SetupProgress({
                   })
                 }
               } else if (currentEvent === "complete") {
+                // Invalidate the project-issues cache so the issue immediately
+                // disappears from the "Issues" column (it now has maestro:planning label)
+                queryClient.invalidateQueries({ queryKey: ["project-issues", projectId] })
                 onComplete({
                   sessionId: data.sessionId,
                   worktreePath: data.worktreePath,
@@ -201,7 +206,7 @@ export function SetupProgress({
       setPipelineError(message)
       onError({ step: "Connection", error: message })
     }
-  }, [projectId, issueNumber, issueTitle, onComplete, onError])
+  }, [projectId, issueNumber, issueTitle, onComplete, onError, queryClient])
 
   useEffect(() => {
     startPipeline()

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared constants for use in both client and server components.
+ * 
+ * IMPORTANT: Keep this file free of server-only imports (child_process, fs, etc.)
+ * to ensure it can be safely imported by React client components.
+ * 
+ * This file defines constants related to the planning workflow state management
+ * using GitHub labels as the persistence mechanism.
+ */
+
+/**
+ * GitHub label applied to issues that are currently in the planning phase.
+ * 
+ * When a user starts planning an issue in Maestro:
+ * 1. This label is added to the GitHub issue
+ * 2. Issue is filtered out of "Open Issues" sections
+ * 3. Issue appears only in "Planning" sections
+ * 
+ * When planning ends:
+ * 1. This label is removed from the GitHub issue
+ * 2. Issue returns to "Open Issues" sections
+ */
+export const PLANNING_LABEL = "maestro:planning";
+
+/**
+ * Color for the planning label (GitHub hex format, without # prefix).
+ * 
+ * Purple (7057ff) was chosen because:
+ * - Distinct from common label colors (red=bug, green=enhancement, blue=question)
+ * - Suggests "in progress" or "workflow state"
+ * - Matches Maestros primary purple branding
+ */
+export const PLANNING_LABEL_COLOR = "7057ff";
+
+/**
+ * Description text for the planning label.
+ * Shown in GitHub UI when hovering over the label.
+ */
+export const PLANNING_LABEL_DESCRIPTION = "Issue is being planned in Maestro";

--- a/src/lib/services/github-labels.ts
+++ b/src/lib/services/github-labels.ts
@@ -1,0 +1,152 @@
+/**
+ * GitHub label management service for planning workflow state.
+ * 
+ * This service provides functions to add/remove the maestro:planning label
+ * on GitHub issues, which is used to filter issues out of "Open Issues" views
+ * while they are in active planning.
+ * 
+ * Uses the GitHub CLI (gh) for all operations. Requires gh to be installed
+ * and authenticated.
+ */
+
+import { exec } from "child_process";
+import { promisify } from "util";
+import { 
+  PLANNING_LABEL, 
+  PLANNING_LABEL_COLOR, 
+  PLANNING_LABEL_DESCRIPTION 
+} from "@/lib/constants";
+
+const execAsync = promisify(exec);
+
+// Re-export constants for server-side convenience
+export { PLANNING_LABEL, PLANNING_LABEL_COLOR };
+
+/**
+ * Ensure the maestro:planning label exists in the repository.
+ * Creates the label with standard color/description if it doesnt exist.
+ * 
+ * This is called before adding the label to an issue to ensure
+ * the label exists. Its idempotent - safe to call multiple times.
+ * 
+ * @param projectPath - Absolute path to the git repository
+ * @throws Error if GitHub CLI fails (network, auth, etc.)
+ */
+export async function ensurePlanningLabel(projectPath: string): Promise<void> {
+  try {
+    // Check if label already exists
+    await execAsync(`gh label view "${PLANNING_LABEL}"`, { cwd: projectPath });
+    // Label exists, nothing to do
+  } catch {
+    // Label doesnt exist (gh label view returns non-zero), create it
+    await execAsync(
+      `gh label create "${PLANNING_LABEL}" --color "${PLANNING_LABEL_COLOR}" --description "${PLANNING_LABEL_DESCRIPTION}"`,
+      { cwd: projectPath }
+    );
+  }
+}
+
+/**
+ * Add the planning label to a GitHub issue.
+ * 
+ * This function:
+ * 1. Ensures the label exists in the repository
+ * 2. Adds the label to the specified issue
+ * 
+ * If the label is already on the issue, GitHub CLI handles this gracefully
+ * (no error, just a no-op).
+ * 
+ * @param projectPath - Absolute path to the git repository
+ * @param issueNumber - GitHub issue number to label
+ * @throws Error if GitHub CLI fails
+ * 
+ * @example
+ * ```typescript
+ * await addPlanningLabel("/Users/me/my-repo", 42);
+ * // Issue #42 now has the maestro:planning label
+ * ```
+ */
+export async function addPlanningLabel(
+  projectPath: string,
+  issueNumber: number
+): Promise<void> {
+  // First ensure the label exists in the repo
+  await ensurePlanningLabel(projectPath);
+  
+  // Add the label to the issue
+  await execAsync(
+    `gh issue edit ${issueNumber} --add-label "${PLANNING_LABEL}"`,
+    { cwd: projectPath }
+  );
+}
+
+/**
+ * Remove the planning label from a GitHub issue.
+ * 
+ * Fails silently if:
+ * - The label doesnt exist on the issue
+ * - The label doesnt exist in the repository
+ * 
+ * This is intentional - we care about the end state (no label), not
+ * whether the label was there before.
+ * 
+ * @param projectPath - Absolute path to the git repository
+ * @param issueNumber - GitHub issue number to unlabel
+ * @throws Error only for unexpected failures (network, auth)
+ * 
+ * @example
+ * ```typescript
+ * await removePlanningLabel("/Users/me/my-repo", 42);
+ * // Issue #42 no longer has the maestro:planning label
+ * ```
+ */
+export async function removePlanningLabel(
+  projectPath: string,
+  issueNumber: number
+): Promise<void> {
+  try {
+    await execAsync(
+      `gh issue edit ${issueNumber} --remove-label "${PLANNING_LABEL}"`,
+      { cwd: projectPath }
+    );
+  } catch (err) {
+    // Check if this is a "label not found" error - thats OK
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("not found") || message.includes("does not exist")) {
+      // Label wasnt on the issue or doesnt exist - this is fine
+      return;
+    }
+    // Re-throw other errors (network, auth, etc.)
+    throw err;
+  }
+}
+
+/**
+ * Check if an issue has the planning label.
+ * 
+ * This is a pure function that operates on the labels array from a GitHub issue.
+ * It does NOT make any API calls - use this for filtering in UI components.
+ * 
+ * @param labels - Array of label objects from GitHub issue (must have name property)
+ * @returns true if the issue has the maestro:planning label
+ * 
+ * @example
+ * ```typescript
+ * const issues = await fetchIssues();
+ * const openIssues = issues.filter(issue => !hasPlanningLabel(issue.labels));
+ * ```
+ */
+export function hasPlanningLabel(labels: { name: string }[]): boolean {
+  return labels.some(label => label.name === PLANNING_LABEL);
+}
+
+/**
+ * Type guard to check if an issue is in planning state.
+ * Alias for hasPlanningLabel with clearer intent.
+ * 
+ * @param labels - Array of label objects from GitHub issue
+ * @returns true if issue is currently being planned
+ */
+export function isInPlanning(labels: { name: string }[]): boolean {
+  return hasPlanningLabel(labels);
+}


### PR DESCRIPTION
## Summary

This PR implements planning state management using GitHub labels to filter issues from "Open Issues" sections while they're being actively planned.

### Changes

- **Label Management**: When a user starts planning an issue, the `maestro:planning` label is automatically added to the GitHub issue
- **Issue Filtering**: Issues with this label are filtered out from:
  - Sidebar "Open Issues" section
  - Desktop kanban "Issues" column  
  - Mobile accordion "Issues" section
- **End Planning Flow**: New "End Planning" button in planning header with confirmation dialog
- **Cache Invalidation**: Immediate UI updates when planning starts/ends (no manual refresh needed)

### New Files

- `/src/lib/constants.ts` - Shared constants for planning label
- `/src/lib/services/github-labels.ts` - GitHub label management service
- `/src/app/api/projects/[id]/planning/[issueNumber]/end/route.ts` - End planning endpoint
- `/src/components/ui/alert-dialog.tsx` - AlertDialog component (shadcn)

### Modified Files

- `start/route.ts` - Adds label when planning starts
- `app-sidebar.tsx` - Filters issues by planning label
- `page.tsx` - Filters kanban/mobile by planning label
- `PlanningHeader.tsx` - Added End Planning button with dialog
- `SetupProgress.tsx` - Cache invalidation on planning start

Closes #15