### PR TITLE
feat: Make Planning Phase UI Responsive and Improve BeadDetail UX

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -200,6 +200,51 @@ body {
   }
 }
 
+/* Markdown/Streamdown content overflow handling */
+[data-streamdown="table-wrapper"] {
+  max-width: 100%;
+  overflow-x: auto;
+  display: block;
+}
+
+[data-streamdown="table-wrapper"] > div {
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+[data-streamdown="table"] {
+  min-width: 0;
+  width: max-content;
+  max-width: none;
+}
+
+/* Force all streamdown content to respect container width */
+[class*="streamdown"],
+.sd-root {
+  max-width: 100%;
+  min-width: 0;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+/* Ensure pre blocks with code don't overflow */
+[data-streamdown="code-block"] {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+/* Planning chat specific overflow handling */
+.planning-chat-content {
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: hidden;
+}
+
+/* Ensure message content containers don't overflow */
+[data-streamdown] {
+  max-width: 100%;
+}
+
 /* Safe area utilities for iOS notch/home indicator */
 .safe-top {
   padding-top: env(safe-area-inset-top, 0);

--- a/src/app/project/[id]/layout.tsx
+++ b/src/app/project/[id]/layout.tsx
@@ -11,8 +11,8 @@ export default function ProjectLayout({
   return (
     <SidebarProvider>
       <AppSidebar />
-      <SidebarInset>
-        <main className="flex-1 overflow-hidden">
+      <SidebarInset className="min-w-0 overflow-hidden">
+        <main className="flex-1 overflow-hidden min-w-0">
           {children}
         </main>
       </SidebarInset>

--- a/src/app/project/[id]/planning/[issueNumber]/page.tsx
+++ b/src/app/project/[id]/planning/[issueNumber]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -11,6 +11,7 @@ import {
 } from "@/components/planning";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useBeadsWatch } from "@/lib/hooks/useBeadsWatch";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 interface GitHubIssue {
   number: number;
@@ -23,32 +24,6 @@ interface GitHubIssue {
 interface BeadContext {
   id: string;
   title: string;
-}
-
-// Desktop breakpoint (lg: 1024px)
-const DESKTOP_BREAKPOINT = 1024;
-
-function useIsDesktop() {
-  const subscribe = useCallback((callback: () => void) => {
-    const mql = window.matchMedia(`(min-width: ${DESKTOP_BREAKPOINT}px)`);
-    mql.addEventListener("change", callback);
-    window.addEventListener("resize", callback);
-    return () => {
-      mql.removeEventListener("change", callback);
-      window.removeEventListener("resize", callback);
-    };
-  }, []);
-
-  const getSnapshot = useCallback(() => {
-    return window.innerWidth >= DESKTOP_BREAKPOINT;
-  }, []);
-
-  const getServerSnapshot = useCallback(() => {
-    // Default to desktop on server
-    return true;
-  }, []);
-
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
 export default function PlanningPage() {
@@ -64,7 +39,8 @@ export default function PlanningPage() {
   const [issueError, setIssueError] = useState<string | null>(null);
 
   // Layout state
-  const isDesktop = useIsDesktop();
+  const isMobile = useIsMobile();
+  const isDesktop = !isMobile;
   const [activeTab, setActiveTab] = useState<"setup" | "plan">("setup");
 
   // Beads tracking for unread indicator (mobile only)
@@ -234,10 +210,10 @@ export default function PlanningPage() {
           projectName="Project"
         />
 
-        <div ref={containerRef} className="flex-1 overflow-hidden flex">
+        <div ref={containerRef} className="flex-1 overflow-hidden flex min-h-0">
           {/* Left Pane */}
           <div
-            className="flex flex-col border-r border-border overflow-hidden relative flex-shrink-0"
+            className="flex flex-col border-r border-border overflow-hidden relative flex-shrink-0 min-w-0"
             style={{ width: `${leftPanelPercent}%` }}
           >
             {/* Drag handle */}
@@ -260,7 +236,7 @@ export default function PlanningPage() {
 
           {/* Right Pane */}
           <div
-            className="flex flex-col flex-1 overflow-hidden"
+            className="flex flex-col flex-1 overflow-hidden min-w-0"
             style={{ width: `${100 - leftPanelPercent}%` }}
           >
             <PlanningRightPane
@@ -315,7 +291,7 @@ export default function PlanningPage() {
       </div>
 
       {/* Tab content */}
-      <div className="flex-1 overflow-hidden">
+      <div className="flex-1 overflow-hidden min-w-0 min-h-0">
         {activeTab === "setup" ? (
           <PlanningLeftPane
             projectId={projectId}

--- a/src/components/ai-elements/conversation.tsx
+++ b/src/components/ai-elements/conversation.tsx
@@ -11,7 +11,7 @@ export type ConversationProps = ComponentProps<typeof StickToBottom>;
 
 export const Conversation = ({ className, ...props }: ConversationProps) => (
   <StickToBottom
-    className={cn("relative flex-1 overflow-y-hidden", className)}
+    className={cn("relative flex-1 overflow-y-hidden overflow-x-hidden min-w-0", className)}
     initial="smooth"
     resize="smooth"
     role="log"
@@ -28,7 +28,7 @@ export const ConversationContent = ({
   ...props
 }: ConversationContentProps) => (
   <StickToBottom.Content
-    className={cn("flex flex-col gap-8 p-4", className)}
+    className={cn("flex flex-col gap-8 p-4 min-w-0", className)}
     {...props}
   />
 );

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -30,7 +30,7 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
-      "group flex w-full max-w-[95%] flex-col gap-2",
+      "group flex w-full max-w-[95%] flex-col gap-2 min-w-0",
       from === "user" ? "is-user ml-auto justify-end" : "is-assistant",
       className
     )}
@@ -47,9 +47,9 @@ export const MessageContent = ({
 }: MessageContentProps) => (
   <div
     className={cn(
-      "is-user:dark flex w-fit max-w-full min-w-0 flex-col gap-2 overflow-hidden text-sm",
-      "group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
-      "group-[.is-assistant]:text-foreground",
+      "is-user:dark flex min-w-0 flex-col gap-2 overflow-x-auto text-sm",
+      "group-[.is-user]:w-fit group-[.is-user]:max-w-full group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
+      "group-[.is-assistant]:w-full group-[.is-assistant]:max-w-full group-[.is-assistant]:text-foreground",
       className
     )}
     {...props}
@@ -310,7 +310,7 @@ export const MessageResponse = memo(
   ({ className, ...props }: MessageResponseProps) => (
     <Streamdown
       className={cn(
-        "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+        "size-full min-w-0 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_table]:block [&_table]:overflow-x-auto [&_table]:max-w-full",
         className
       )}
       {...props}

--- a/src/components/planning/BeadDetail.tsx
+++ b/src/components/planning/BeadDetail.tsx
@@ -121,21 +121,18 @@ export function BeadDetail({
   return (
     <div className="flex flex-col h-full overflow-hidden bg-card">
       {/* Header */}
-      <div className="flex items-start justify-between gap-3 p-4 border-b border-border">
-        <div className="min-w-0 flex-1">
-          <h2 className="text-base font-semibold leading-tight truncate">
-            {bead.id}: {bead.title}
-          </h2>
-        </div>
-        <Button
-          variant="ghost"
-          size="icon-sm"
+      <div className="flex items-center justify-between gap-3 p-4 border-b border-border">
+        <h2 className="text-base font-semibold leading-tight truncate min-w-0 flex-1">
+          {bead.id}: {bead.title}
+        </h2>
+        <button
+          type="button"
           onClick={onClose}
-          className="flex-shrink-0"
+          className="flex-shrink-0 h-8 w-8 flex items-center justify-center rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
           aria-label="Close detail panel"
         >
-          <X className="h-4 w-4" />
-        </Button>
+          <X className="h-5 w-5" strokeWidth={1.5} />
+        </button>
       </div>
 
       {/* Content */}
@@ -256,23 +253,23 @@ export function BeadDetail({
       </div>
 
       {/* Footer actions - min 44px touch targets */}
-      <div className="flex items-center gap-2 p-4 border-t border-border safe-bottom">
+      <div className="flex items-center justify-center gap-3 p-4 border-t border-border">
         <Button
           variant="outline"
           size="sm"
           onClick={() => onChatAbout(bead.id)}
-          className="flex-1 sm:flex-none h-11 min-w-[44px]"
+          className="h-10"
         >
-          <MessageSquare className="h-4 w-4 mr-1.5" />
+          <MessageSquare className="h-4 w-4 mr-2" />
           Chat about this
         </Button>
         <Button
           variant="outline"
           size="sm"
           onClick={() => setShowDeleteDialog(true)}
-          className="text-destructive hover:text-destructive hover:bg-destructive/10 h-11 min-w-[44px]"
+          className="text-destructive hover:text-destructive hover:bg-destructive/10 h-10"
         >
-          <Trash2 className="h-4 w-4 mr-1.5" />
+          <Trash2 className="h-4 w-4 mr-2" />
           Delete
         </Button>
       </div>

--- a/src/components/planning/PlanningChat.tsx
+++ b/src/components/planning/PlanningChat.tsx
@@ -436,8 +436,8 @@ export function PlanningChat({
   // Loading history state
   if (isLoadingHistory) {
     return (
-      <div className="flex flex-col h-full">
-        <div className="flex-1 flex flex-col items-center justify-center p-4">
+      <div className="flex flex-col h-full min-w-0 overflow-hidden">
+        <div className="flex-1 flex flex-col items-center justify-center p-4 min-w-0">
           <Loader size={24} className="text-muted-foreground mb-3" />
           <p className="text-xs text-muted-foreground">Loading chat history...</p>
         </div>
@@ -448,8 +448,8 @@ export function PlanningChat({
   // Initial prompt pending state - show that the AI is analyzing
   if (isInitialPromptPending && messages.length === 0) {
     return (
-      <div className="flex flex-col h-full">
-        <div className="flex-1 flex flex-col items-center justify-center p-4">
+      <div className="flex flex-col h-full min-w-0 overflow-hidden">
+        <div className="flex-1 flex flex-col items-center justify-center p-4 min-w-0">
           <Loader size={24} className="text-muted-foreground mb-3" />
           <p className="text-sm font-medium text-foreground mb-1">Analyzing issue...</p>
           <p className="text-xs text-muted-foreground text-center max-w-xs">
@@ -463,9 +463,9 @@ export function PlanningChat({
   // Empty state (only show if not loading history and no initial prompt pending)
   if (messages.length === 0 && !streamState.isStreaming && !isLoadingHistory && !isInitialPromptPending) {
     return (
-      <div className="flex flex-col h-full">
+      <div className="flex flex-col h-full min-w-0 overflow-hidden">
         {/* Empty state */}
-        <div className="flex-1 flex flex-col items-center justify-center p-4">
+        <div className="flex-1 flex flex-col items-center justify-center p-4 min-w-0">
           <MessageSquare className="h-12 w-12 text-muted-foreground/30 mb-3" />
           <h3 className="font-medium text-sm text-foreground">
             Planning Chat
@@ -478,7 +478,7 @@ export function PlanningChat({
         </div>
 
         {/* Input area */}
-        <div className="border-t border-border bg-card p-3">
+        <div className="border-t border-border bg-card p-3 min-w-0">
           {/* Context indicator */}
           {selectedBead && (
             <div className="flex items-center gap-2 px-3 py-2 bg-accent/50 rounded-t-md mb-2">
@@ -529,7 +529,7 @@ export function PlanningChat({
   }
 
   return (
-    <div className="flex flex-col h-full overflow-hidden">
+    <div className="flex flex-col h-full overflow-hidden min-w-0">
       {/* Header with actions */}
       {onNewSession && (
         <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-card/50">
@@ -549,8 +549,8 @@ export function PlanningChat({
       )}
 
       {/* Messages */}
-      <Conversation className="flex-1">
-        <ConversationContent className="gap-4">
+      <Conversation className="flex-1 min-w-0">
+        <ConversationContent className="gap-4 min-w-0">
           {messages.map((message) => (
             <Message key={message.id} from={message.role}>
               {message.role === "assistant" ? (
@@ -651,7 +651,7 @@ export function PlanningChat({
       )}
 
       {/* Input area */}
-      <div className="border-t border-border bg-card p-3">
+      <div className="border-t border-border bg-card p-3 min-w-0">
         {/* Context indicator */}
         {selectedBead && (
           <div className="flex items-center gap-2 px-3 py-2 bg-accent/50 rounded-t-md mb-2">

--- a/src/components/planning/PlanningHeader.tsx
+++ b/src/components/planning/PlanningHeader.tsx
@@ -24,23 +24,28 @@ export function PlanningHeader({
         <SidebarTrigger className="lg:hidden" />
 
         {/* Breadcrumb navigation */}
-        <nav className="flex items-center gap-1 text-sm min-w-0 flex-1">
+        <nav className="flex items-center gap-1 text-sm min-w-0 flex-1 overflow-hidden">
+          {/* Project name - can truncate on small screens */}
           <Link
             href={`/project/${projectId}`}
-            className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+            className="text-muted-foreground hover:text-foreground transition-colors truncate max-w-[100px] sm:max-w-[150px] lg:max-w-none"
           >
             {projectName}
           </Link>
           <ChevronRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-          <span className="text-muted-foreground flex-shrink-0">Planning</span>
-          <ChevronRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-          <span className="font-medium truncate">
+
+          {/* "Planning" segment - hidden on very small screens */}
+          <span className="text-muted-foreground flex-shrink-0 hidden sm:inline">
+            Planning
+          </span>
+          <ChevronRight className="h-4 w-4 text-muted-foreground flex-shrink-0 hidden sm:inline" />
+
+          {/* Issue number and title - always visible */}
+          <span className="font-medium truncate min-w-0">
             #{issueNumber}
             {issueTitle && (
               <span className="text-muted-foreground font-normal ml-1">
-                {issueTitle.length > 40
-                  ? `${issueTitle.slice(0, 40)}...`
-                  : issueTitle}
+                {issueTitle}
               </span>
             )}
           </span>

--- a/src/components/planning/PlanningLeftPane.tsx
+++ b/src/components/planning/PlanningLeftPane.tsx
@@ -230,8 +230,8 @@ export function PlanningLeftPane({
   // Loading state while checking for existing session
   if (setupState === "checking") {
     return (
-      <div className="flex flex-col h-full overflow-hidden">
-        <div className="flex-1 flex items-center justify-center">
+      <div className="flex flex-col h-full overflow-hidden min-w-0">
+        <div className="flex-1 flex items-center justify-center min-w-0">
           <div className="flex flex-col items-center gap-3">
             <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             <p className="text-sm text-muted-foreground">
@@ -246,8 +246,8 @@ export function PlanningLeftPane({
   // Pending state - show Start Planning button
   if (setupState === "pending") {
     return (
-      <div className="flex flex-col h-full overflow-hidden">
-        <div className="flex-1 flex items-center justify-center">
+      <div className="flex flex-col h-full overflow-hidden min-w-0">
+        <div className="flex-1 flex items-center justify-center min-w-0">
           <div className="flex flex-col items-center gap-4 text-center px-4">
             <div className="flex flex-col items-center gap-2">
               <h3 className="text-lg font-medium">Ready to Plan</h3>
@@ -268,8 +268,8 @@ export function PlanningLeftPane({
   // Setup in progress
   if (setupState === "in_progress") {
     return (
-      <div className="flex flex-col h-full overflow-hidden">
-        <div className="p-4 border-b border-border">
+      <div className="flex flex-col h-full overflow-hidden min-w-0">
+        <div className="p-4 border-b border-border min-w-0">
           <SetupProgress
             projectId={projectId}
             issueNumber={issueNumber}
@@ -280,7 +280,7 @@ export function PlanningLeftPane({
           />
         </div>
         {/* Show chat once session is created (before setup fully completes) */}
-        <div className="flex-1 overflow-hidden">
+        <div className="flex-1 overflow-hidden min-w-0">
           {sessionInfo ? (
             <PlanningChat
               projectId={projectId}
@@ -306,8 +306,8 @@ export function PlanningLeftPane({
   // Error state
   if (setupState === "error") {
     return (
-      <div className="flex flex-col h-full overflow-hidden">
-        <div className="p-4">
+      <div className="flex flex-col h-full overflow-hidden min-w-0">
+        <div className="p-4 min-w-0">
           <div className="flex items-start gap-3 p-3 bg-destructive/10 rounded-md border border-destructive/30">
             <AlertCircle className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
             <div className="flex-1 min-w-0">
@@ -337,7 +337,7 @@ export function PlanningLeftPane({
 
   // Completed state - show collapsible summary and chat
   return (
-    <div className="flex flex-col h-full overflow-hidden">
+    <div className="flex flex-col h-full overflow-hidden min-w-0">
       {/* Setup Summary (collapsible) */}
       {sessionInfo && (
         <SetupSummary
@@ -349,7 +349,7 @@ export function PlanningLeftPane({
       )}
 
       {/* Chat section fills remaining space */}
-      <div className="flex-1 overflow-hidden">
+      <div className="flex-1 overflow-hidden min-w-0">
         <PlanningChat
           projectId={projectId}
           issueNumber={issueNumber}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -48,9 +48,11 @@ function SheetContent({
   className,
   children,
   side = "right",
+  showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
 }) {
   return (
     <SheetPortal>
@@ -72,10 +74,12 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-          <XIcon className="size-4" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
+        {showCloseButton && (
+          <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
       </SheetPrimitive.Content>
     </SheetPortal>
   )

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -207,7 +207,7 @@ function Sidebar({
 
   return (
     <div
-      className="group peer text-sidebar-foreground hidden md:block"
+      className="group peer text-sidebar-foreground hidden lg:block"
       data-state={state}
       data-collapsible={state === "collapsed" ? collapsible : ""}
       data-variant={variant}
@@ -229,7 +229,7 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
@@ -291,7 +291,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] lg:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
@@ -310,7 +310,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
       data-slot="sidebar-inset"
       className={cn(
         "bg-background relative flex w-full flex-1 flex-col",
-        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "lg:peer-data-[variant=inset]:m-2 lg:peer-data-[variant=inset]:ml-0 lg:peer-data-[variant=inset]:rounded-xl lg:peer-data-[variant=inset]:shadow-sm lg:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}
       {...props}
@@ -428,7 +428,7 @@ function SidebarGroupAction({
       className={cn(
         "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
-        "after:absolute after:-inset-2 md:after:hidden",
+        "after:absolute after:-inset-2 lg:after:hidden",
         "group-data-[collapsible=icon]:hidden",
         className
       )}
@@ -563,13 +563,13 @@ function SidebarMenuAction({
       className={cn(
         "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
-        "after:absolute after:-inset-2 md:after:hidden",
+        "after:absolute after:-inset-2 lg:after:hidden",
         "peer-data-[size=sm]/menu-button:top-1",
         "peer-data-[size=default]/menu-button:top-1.5",
         "peer-data-[size=lg]/menu-button:top-2.5",
         "group-data-[collapsible=icon]:hidden",
         showOnHover &&
-          "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+          "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 lg:opacity-0",
         className
       )}
       {...props}

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-const MOBILE_BREAKPOINT = 768
+const MOBILE_BREAKPOINT = 1024
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)


### PR DESCRIPTION
## Summary

- Make desktop BeadDetail slide-out panel 75% width of plan view
- Fix footer button padding and center alignment in BeadDetail
- Increase mobile bottom sheet height to 92vh for better content visibility
- Add `showCloseButton` prop to Sheet component to fix duplicate close button issue
- Update sidebar and layout breakpoints from `md` to `lg` for consistent responsive behavior
- Add overflow handling for markdown/streamdown content in planning chat

Closes #17